### PR TITLE
fix build by adding missing comma

### DIFF
--- a/src/cli/redux-generate.js
+++ b/src/cli/redux-generate.js
@@ -30,7 +30,7 @@ commander
         rawArgs
       },
       debug,
-      path
+      path,
       dryRun
     };
     subCommand.run(blueprintName, cliArgs);


### PR DESCRIPTION
Thanks for your work on getting path working! Planning on using this quite a bit.

I needed to add this missing comma to get the build to go through.

Also, it seems that your PR on the original repo needs to be rebased in order to be merged.